### PR TITLE
Improve check if HEAD is ahead of remote

### DIFF
--- a/profile/reports/is_ahead_is_ancestor.py
+++ b/profile/reports/is_ahead_is_ancestor.py
@@ -1,0 +1,42 @@
+import time
+from tempfile import TemporaryDirectory
+
+from git_inspector.common import is_ancestors_of, is_ahead_of
+from tests.testutils import create_repo, add_n_big_commits
+
+
+def test_is_ahead_vs_is_ancestor_of():
+    print()
+    n_commits = 1000
+    with TemporaryDirectory() as directory:
+        repo = create_repo(directory)
+        add_n_big_commits(repo, n_commits + 1)
+        ancestor_commit = repo.commit(f"HEAD~{n_commits}")
+        commit = repo.commit("HEAD")
+
+        elapsed_time_is_ahead_of = measure_is_ahead_of(repo=repo,
+                                                       ancestor=ancestor_commit,
+                                                       commit=commit)
+        print(f"Elapsed time for 'is_ahead_of' {elapsed_time_is_ahead_of * 1000} ms")
+
+        elapsed_time_is_ancestor_of = measure_is_ancestor_of(ancestor=ancestor_commit,
+                                                             commit=commit)
+        print(f"Elapsed time for 'is_ancestors_of' {elapsed_time_is_ancestor_of * 1000} ms")
+
+
+def measure_is_ancestor_of(ancestor, commit):
+    start_is_ancestor_of = time.time()
+    is_ancestor = is_ancestors_of(ancestor=ancestor, commit=commit)
+    stop_is_ancestor_of = time.time()
+    assert is_ancestor
+    elapsed_time_is_ancestor_of = stop_is_ancestor_of - start_is_ancestor_of
+    return elapsed_time_is_ancestor_of
+
+
+def measure_is_ahead_of(repo, ancestor, commit):
+    start_is_ahead_of = time.time()
+    is_ahead = is_ahead_of(repo=repo, ancestor=ancestor, commit=commit)
+    stop_is_ahead_of = time.time()
+    assert is_ahead
+    elapsed_time_is_ahead_of = stop_is_ahead_of - start_is_ahead_of
+    return elapsed_time_is_ahead_of

--- a/src/git_inspector/common.py
+++ b/src/git_inspector/common.py
@@ -41,30 +41,21 @@ def is_ancestors_of(ancestor: Commit, commit: Commit):
     return depth_search_commit([commit], [], ancestor) is not None
 
 
-def depth_search_commit(fringe: iter, visited: list, goal_node: Commit, cur_dept=0):
-    if len(fringe) == 0:
-        return None
-    if cur_dept >= 100:
-        logging.debug(f"max depth reached for is_ancestors_of of {goal_node.repo.working_dir}")
-        return None
-    if goal_node in fringe:
-        return 0
-    new_fringe = []
-    for fring in fringe:
-        f_parents = fring.parents
-        new_fringe.extend(f_parents)
-    new_fringe = [x for x in new_fringe if x not in visited]
-    visited += fringe
-    try:
-        dept = depth_search_commit(new_fringe, visited, goal_node, cur_dept + 1)
-    except ValueError as e:
-        # A value error like the following is risen if the remote can not be resolved any further
-        # ValueError: SHA b'7692881d2a61a4ba47eeef5d7827c0d2cb896def' could not be resolved, git returned:
-        # b'7692881d2a61a4ba47eeef5d7827c0d2cb896def missing
-        raise CommitResolveError(e)
-    if dept is not None:
-        return dept + 1
-    return None
+def depth_search_commit(fringe: iter, visited: list, goal_node: Commit):
+    cur_dept = 0
+    while True:
+        if len(fringe) == 0:
+            return None
+        if goal_node in fringe:
+            return cur_dept
+        new_fringe = []
+        for fring in fringe:
+            f_parents = fring.parents
+            new_fringe.extend(f_parents)
+        new_fringe = [x for x in new_fringe if x not in visited]
+        visited += fringe
+        fringe = new_fringe
+        cur_dept += 1
 
 
 def remote_is_gone(remote: Remote):

--- a/src/git_inspector/common.py
+++ b/src/git_inspector/common.py
@@ -1,7 +1,6 @@
 import os
 
-from git import Commit, Remote
-import logging
+from git import Commit, Remote, Repo
 
 
 class CommitResolveError(Exception):
@@ -35,6 +34,11 @@ def get_master_branch(repo):
 
 def get_non_master_branches(repo):
     return list(filter(lambda x: not is_master_branch(x), repo.heads))
+
+
+def is_ahead_of(repo: Repo, ancestor: Commit, commit: Commit):
+    commits_ahead = repo.iter_commits(f'{ancestor}..{commit}')
+    return any(True for _ in commits_ahead)
 
 
 def is_ancestors_of(ancestor: Commit, commit: Commit):

--- a/src/git_inspector/reports/unpushed.py
+++ b/src/git_inspector/reports/unpushed.py
@@ -1,8 +1,9 @@
 from typing import List
 
 from git import Repo, RemoteReference
-from ..common import is_ancestors_of, CommitResolveError, remote_is_gone
+
 from .report import ReportType, GIT_REPORT_LEVEL_WARNING, Report
+from ..common import CommitResolveError, is_ahead_of
 
 unpushed_report = ReportType(
     'unpushed',
@@ -39,7 +40,7 @@ def get_unpushed_branches(repo: Repo):
         if remote_commit == local_commit:
             continue
         try:
-            local_is_ahead_remote = is_ancestors_of(ancestor=remote_commit, commit=local_commit)
+            local_is_ahead_remote = is_ahead_of(repo=repo, ancestor=remote_commit, commit=local_commit)
             if local_is_ahead_remote:
                 unpushed_heads.append(head)
         except CommitResolveError:

--- a/tests/common/test_is_ahead_of.py
+++ b/tests/common/test_is_ahead_of.py
@@ -1,0 +1,67 @@
+from git import Repo
+
+from src.git_inspector.common import is_ahead_of
+from tests.testutils import add_ahead_branch
+
+
+def test_same_commit(repo: Repo):
+    assert not is_ahead_of(
+        repo=repo,
+        ancestor=repo.commit("HEAD"),
+        commit=repo.commit("HEAD"))
+
+
+def test_direct_ancestor(repo: Repo):
+    assert is_ahead_of(
+        repo=repo,
+        ancestor=repo.commit("HEAD~1"),
+        commit=repo.commit("HEAD"))
+
+
+def test_direct_successor(repo: Repo):
+    assert not is_ahead_of(
+        repo=repo,
+        ancestor=repo.commit("HEAD"),
+        commit=repo.commit("HEAD~1"))
+
+
+def test_distant_ancestor(repo: Repo):
+    assert is_ahead_of(
+        repo=repo,
+        ancestor=repo.commit("HEAD~2"),
+        commit=repo.commit("HEAD"))
+
+
+def test_distant_successor(repo: Repo):
+    assert not is_ahead_of(
+        repo=repo,
+        ancestor=repo.commit("HEAD"),
+        commit=repo.commit("HEAD~2"))
+
+
+def test_ahead_branch(repo: Repo):
+    ahead_branch = add_ahead_branch(repo)
+    assert is_ahead_of(
+        repo=repo,
+        ancestor=repo.commit("HEAD"),
+        commit=ahead_branch.commit
+    )
+
+
+def test_behind_branch(repo: Repo):
+    ahead_branch = add_ahead_branch(repo)
+    assert not is_ahead_of(
+        repo=repo,
+        ancestor=ahead_branch.commit,
+        commit=repo.commit("HEAD")
+    )
+
+
+def test_different_branches(repo: Repo):
+    branch1 = add_ahead_branch(repo, "branch1")
+    branch2 = add_ahead_branch(repo, "branch2")
+    assert is_ahead_of(
+        repo=repo,
+        ancestor=branch1.commit,
+        commit=branch2.commit
+    )

--- a/tests/common/test_is_ancestor_of.py
+++ b/tests/common/test_is_ancestor_of.py
@@ -1,7 +1,7 @@
 from git import Repo
 from git_inspector.common import is_ancestors_of
 
-from tests.testutils import add_ahead_branch
+from tests.testutils import add_ahead_branch, add_n_commits
 
 
 def test_same_commit(repo: Repo):
@@ -28,10 +28,26 @@ def test_distant_ancestor(repo: Repo):
         commit=repo.commit("HEAD"))
 
 
+def test_very_distant_ancestor(repo: Repo):
+    n_commits = 1_000
+    add_n_commits(repo, n_commits)
+    assert is_ancestors_of(
+        ancestor=repo.commit(f"HEAD~{n_commits}"),
+        commit=repo.commit("HEAD"))
+
+
 def test_distant_successor(repo: Repo):
     assert not is_ancestors_of(
         ancestor=repo.commit("HEAD"),
         commit=repo.commit("HEAD~2"))
+
+
+def test_very_distant_successor(repo: Repo):
+    n_commits = 1_000
+    add_n_commits(repo, n_commits)
+    assert not is_ancestors_of(
+        ancestor=repo.commit("HEAD"),
+        commit=repo.commit(f"HEAD~{n_commits}"))
 
 
 def test_ahead_branch(repo: Repo):

--- a/tests/common/test_is_ancestor_of.py
+++ b/tests/common/test_is_ancestor_of.py
@@ -16,7 +16,7 @@ def test_direct_ancestor(repo: Repo):
         commit=repo.commit("HEAD"))
 
 
-def test_reverse_direct_ancestor(repo: Repo):
+def test_direct_successor(repo: Repo):
     assert not is_ancestors_of(
         ancestor=repo.commit("HEAD"),
         commit=repo.commit("HEAD~1"))
@@ -28,13 +28,32 @@ def test_distant_ancestor(repo: Repo):
         commit=repo.commit("HEAD"))
 
 
+def test_distant_successor(repo: Repo):
+    assert not is_ancestors_of(
+        ancestor=repo.commit("HEAD"),
+        commit=repo.commit("HEAD~2"))
+
+
 def test_ahead_branch(repo: Repo):
     ahead_branch = add_ahead_branch(repo)
     assert is_ancestors_of(
         ancestor=repo.commit("HEAD"),
         commit=ahead_branch.commit
     )
+
+
+def test_behind_branch(repo: Repo):
+    ahead_branch = add_ahead_branch(repo)
     assert not is_ancestors_of(
         ancestor=ahead_branch.commit,
         commit=repo.commit("HEAD")
+    )
+
+
+def test_different_branches(repo: Repo):
+    branch1 = add_ahead_branch(repo, "branch1")
+    branch2 = add_ahead_branch(repo, "branch2")
+    assert not is_ancestors_of(
+        ancestor=branch1.commit,
+        commit=branch2.commit
     )

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 
+import lorem as lorem
 from git import Repo
 
 
@@ -30,6 +31,16 @@ def make_repo_dirty(repo: Repo):
 
 def add_n_commits(repo: Repo, n_commits):
     for i in range(n_commits):
+        repo.index.commit(f"commit-changed-{i}")
+
+
+def add_n_big_commits(repo: Repo, n_commits):
+    FILENAME = "big_file.txt"
+    for i in range(n_commits):
+        with open(Path(repo.working_dir) / FILENAME , "w") as big_file:
+            for i in range(100):
+                big_file.write(lorem.paragraph())
+        repo.index.add(FILENAME)
         repo.index.commit(f"commit-changed-{i}")
 
 

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -51,7 +51,7 @@ def add_merged_branch(repo: Repo):
 
 
 def add_ahead_branch(repo: Repo, name='ahead_branch'):
-    repo.index.commit("test")
+    repo.index.commit(f"new_branch_{name}")
     repo.create_head(name, 'HEAD')
     repo.active_branch.commit = repo.commit('HEAD~1')
     assert repo.active_branch.commit == repo.heads[name].commit.parents[0]


### PR DESCRIPTION
The check if my local branch is ahead of remote was really slow for me with a branch that is ~100 commits ahead of the remote branch (I merged some other branch into the branch). It was stuck in depth_search_commit.

Found a faster way to check if local is ahead of remote. 
https://stackoverflow.com/questions/17224134/check-status-of-local-python-relative-to-remote-with-gitpython
No sure though if it does exactly the same as is_ancestors_of